### PR TITLE
Add `set_disk_metadata` as optional API

### DIFF
--- a/lib/bosh/cpi/cli.rb
+++ b/lib/bosh/cpi/cli.rb
@@ -11,6 +11,7 @@ class Bosh::Cpi::Cli
     has_vm
     reboot_vm
     set_vm_metadata
+    set_disk_metadata
     create_disk
     has_disk
     delete_disk

--- a/lib/cloud.rb
+++ b/lib/cloud.rb
@@ -155,6 +155,18 @@ module Bosh
     end
 
     ##
+    # Set metadata for a disk
+    #
+    # Optional. Implement to provide more information for the IaaS.
+    #
+    # @param [String] disk_id disk id that was once returned by {#create_disk}
+    # @param [Hash] metadata metadata key/value pairs
+    # @return [void]
+    def set_disk_metadata(disk_id, metadata)
+      not_implemented(:set_disk_metadata)
+    end
+
+    ##
     # Creates a disk (possibly lazily) that will be attached later to a VM. When
     # VM locality is specified the disk will be placed near the VM so it won't have to move
     # when it's attached later.

--- a/spec/unit/cpi/cli_spec.rb
+++ b/spec/unit/cpi/cli_spec.rb
@@ -252,6 +252,26 @@ describe Bosh::Cpi::Cli do
       end
     end
 
+    describe 'set_disk_metadata' do
+      it 'takes json and calls specified method on the cpi' do
+        allow(cpi).to receive(:set_disk_metadata) { logs_io.write('fake-log') }.and_return(nil)
+
+        subject.run <<-JSON
+          {
+            "method": "set_disk_metadata",
+            "arguments": [
+              "fake-disk-id",
+              {"key": "value"}
+            ],
+            "context" : { "director_uuid" : "abc" }
+          }
+        JSON
+
+        expect(cpi).to have_received(:set_disk_metadata).with('fake-disk-id', {'key' => 'value'})
+        expect(result_io.string).to match(make_result_regexp(nil))
+      end
+    end
+
     describe 'create_disk' do
       it 'takes json and calls specified method on the cpi' do
         expect(cpi).to(receive(:create_disk).


### PR DESCRIPTION
Provide a way for BOSH to specify metadata tags for disks
which can make it easier to identify the origin of the disk.

[#140831863](https://www.pivotaltracker.com/story/show/140831863)

Signed-off-by: Tom Kiemes <tom.kiemes@sap.com>