### PR TITLE
Fix broken unit test

### DIFF
--- a/spec/unit/cpi/cli_spec.rb
+++ b/spec/unit/cpi/cli_spec.rb
@@ -564,7 +564,7 @@ describe Bosh::Cpi::Cli do
     context 'when request json cannot be parsed' do
       it 'returns invalid_call error' do
         subject.run('invalid-json')
-        expect(result_io.string).to match(/{"result":null,"error":{"type":"InvalidCall","message":"Request cannot be deserialized, details: \d+: unexpected token at 'invalid-json'","ok_to_retry":false},"log":/)
+        expect(result_io.string).to match(/{"result":null,"error":{"type":"InvalidCall","message":"Request cannot be deserialized, details: unexpected token at 'invalid-json'","ok_to_retry":false},"log":/)
         expect(result_io.string).to include_the_backtrace
       end
     end


### PR DESCRIPTION
When executing the unit tests on the master branch, I am seeing the following error:

```
Failures:

  1) Bosh::Cpi::Cli#run when request json cannot be parsed returns invalid_call error
     Failure/Error: expect(result_io.string).to match(/{"result":null,"error":{"type":"InvalidCall","message":"Request cannot be deserialized, details: \d+: unexpected token at 'invalid-json'","ok_to_retry":false},"log":/)
     
       expected "{\"result\":null,\"error\":{\"type\":\"InvalidCall\",\"message\":\"Request cannot be deserialized, d...3.2.5/bin/bundle:25:in `load'\\n/Users/sebastian/.rbenv/versions/3.2.5/bin/bundle:25:in `<main>'\"}" to match /{"result":null,"error":{"type":"InvalidCall","message":"Request cannot be deserialized, details: \d+: unexpected token at 'invalid-json'","ok_to_retry":false},"log":/
       Diff:
       @@ -1 +1 @@
       -/{"result":null,"error":{"type":"InvalidCall","message":"Request cannot be deserialized, details: \d+: unexpected token at 'invalid-json'","ok_to_retry":false},"log":/
       +"{\"result\":null,\"error\":{\"type\":\"InvalidCall\",\"message\":\"Request cannot be deserialized, details: unexpected token at 'invalid-json'\",\"ok_to_retry\":false},\"log\"
...
```

The actual response is (prettified):

```json
{
    "result": null,
    "error": {
        "type": "InvalidCall",
        "message": "Request cannot be deserialized, details: unexpected token at 'invalid-json'",
        "ok_to_retry": false
    },
    "log": "Rescued InvalidCall: Request cannot be deserialized, details: unexpected token at 'invalid-json'. backtrace: ...snip..."
}
```

To me it looks like the expectation is wrong. More specifically, the regex needs to be adapted in the `error.message`.

### Environment

- Ruby `3.2.5`

