### PR TITLE
Introduce new cpi method update_disk

### DIFF
--- a/lib/bosh/cpi/cli.rb
+++ b/lib/bosh/cpi/cli.rb
@@ -13,6 +13,7 @@ class Bosh::Cpi::Cli
     set_vm_metadata
     set_disk_metadata
     create_disk
+    update_disk
     has_disk
     delete_disk
     attach_disk

--- a/lib/cloud_v1.rb
+++ b/lib/cloud_v1.rb
@@ -232,6 +232,18 @@ module Bosh
       not_implemented(:resize_disk)
     end
 
+    ##
+    # Updates an existing disk via the IaaS API
+    #
+    # @param [String] disk_id disk id
+    # @param [Integer] new_size disk size in MiB
+    # @param [Hash] cloud_properties properties required for updating this disk
+    #               specific to a CPI
+    # @return [void]
+    def update_disk(disk_id, new_size, cloud_properties)
+      not_implemented(:update_disk)
+    end
+
     # Specify VM's hardware resources
     # @param [Hash] vm_properties (typically cpu, ram, ephemeral_disk_size)
     # @return [Hash] opaque description of the VM's configuration that
@@ -267,4 +279,3 @@ module Bosh
     end
   end
 end
-

--- a/spec/unit/cpi/cli_spec.rb
+++ b/spec/unit/cpi/cli_spec.rb
@@ -345,6 +345,34 @@ describe Bosh::Cpi::Cli do
       end
     end
 
+    describe 'update_disk' do
+      it 'takes json and calls specified method on the cpi' do
+        expect(cpi).to(receive(:update_disk).
+          with('fake-disk-cid', 10240, {
+            'key-int' => 1,
+            'key-str' => 'fake'
+          })) { logs_io.write('fake-log') }.
+          and_return(nil)
+
+        subject.run <<-JSON
+          {
+            "method": "update_disk",
+            "arguments": [
+              "fake-disk-cid",
+              10240,
+              {
+                "key-int": 1,
+                "key-str": "fake"
+              }
+            ],
+            "context" : { "director_uuid" : "abc" }
+          }
+        JSON
+
+        expect(result_io.string).to match(make_result_regexp(nil))
+      end
+    end
+
     describe 'has_disk' do
       [true, false].each do |result|
         it 'takes json and calls specified method on the cpi' do


### PR DESCRIPTION
This update introduces the `update_disk` CPI method, allowing CPIs to directly modify disk properties or expand the disk size. See the related change in BOSH at cloudfoundry/bosh/pull/2555 or discussion cloudfoundry/bosh/issues/2496 for more details.